### PR TITLE
Move deprecated goutte driver to dev dependency, it's only needed for local tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,12 @@
     "require": {
         "behat/behat": "~3.0",
         "behat/mink": "~1.5",
-        "behat/mink-goutte-driver": "~1.0",
         "behat/mink-selenium2-driver": "~1.1",
         "behat/mink-extension": "~2.0"
     },
+    "require-dev": {
+        "behat/mink-goutte-driver": "~1.0",
+    }
     "authors": [
         {
             "name": "Frank Carey",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require-dev": {
         "behat/mink-goutte-driver": "~1.0",
-    }
+    },
     "authors": [
         {
             "name": "Frank Carey",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "behat/mink-extension": "~2.0"
     },
     "require-dev": {
-        "behat/mink-goutte-driver": "~1.0",
+        "behat/mink-goutte-driver": "~1.0"
     },
     "authors": [
         {


### PR DESCRIPTION
Should resolve #10 